### PR TITLE
adds workers and task queues

### DIFF
--- a/modules/utils.ts
+++ b/modules/utils.ts
@@ -1,0 +1,33 @@
+import { StoreService } from "../services/store";
+import { AppSubscriptions, AppTransitions, AppVersion } from "../typedefs/app";
+
+export function findTopKey(obj: AppTransitions, input: string): string | null {
+  for (const [key, value] of Object.entries(obj)) {
+    if (value.hasOwnProperty(input)) {
+      const parentKey = findTopKey(obj, key.replace(/^\./, ''));
+      return (parentKey || key).replace(/^\./, '');
+    }
+  }
+  return null;
+}
+
+export function findSubscriptionForTrigger(obj: AppSubscriptions, value: string): string | null {
+  for (const [key, itemValue] of Object.entries(obj)) {
+      if (itemValue === value) {
+          return key;
+      }
+  }
+  return null;
+}
+
+/**
+ * Get the subscription topic for the flow to which @activityId belongs.
+ * TODO: resolve this value in the compiler...do not call this at runtime
+ */
+export async function getSubscriptionTopic(activityId: string, store: StoreService, config: AppVersion): Promise<string | undefined> {
+  const appTransitions = await store.getTransitions(config);
+  const appSubscriptions = await store.getSubscriptions(config);
+  const triggerId = findTopKey(appTransitions, activityId);
+  const topic = findSubscriptionForTrigger(appSubscriptions, triggerId);
+  return topic;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pubsubdb/pubsubdb",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "The PubSubDB Process Database",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/services/compiler/deployer.ts
+++ b/services/compiler/deployer.ts
@@ -36,7 +36,7 @@ class Deployer {
   }
 
   resolveMappingDependencies() {
-    let dynamicMappingRules: string[] = [];
+    const dynamicMappingRules: string[] = [];
     //recursive function to descend into the object and find all dynamic mapping rules
     function traverse(obj: JsonObject, depends: string[]): void {
       for (const key in obj) {

--- a/services/pubsubdb/activities/activity.ts
+++ b/services/pubsubdb/activities/activity.ts
@@ -1,9 +1,9 @@
-import { RestoreJobContextError, 
-         MapInputDataError, 
-         SubscribeToResponseError, 
-         RegisterTimeoutError, 
-         ExecActivityError, 
-         DuplicateActivityError} from '../../../modules/errors';
+// import { RestoreJobContextError, 
+//          MapInputDataError, 
+//          SubscribeToResponseError, 
+//          RegisterTimeoutError, 
+//          ExecActivityError, 
+//          DuplicateActivityError} from '../../../modules/errors';
 import { PubSubDBService } from "..";
 import { ILogger } from "../../logger";
 import { SignalerService } from "../../signaler";

--- a/services/pubsubdb/activities/trigger.ts
+++ b/services/pubsubdb/activities/trigger.ts
@@ -3,13 +3,13 @@ import { Pipe } from "../../pipe";
 import { KeyType } from '../../store/key';
 import { SerializerService } from '../../store/serializer';
 import { Activity } from "./activity";
-import {
-  RestoreJobContextError, 
-  MapInputDataError, 
-  SubscribeToResponseError, 
-  RegisterTimeoutError, 
-  ExecActivityError, 
-  DuplicateActivityError} from '../../../modules/errors';
+// import {
+//   RestoreJobContextError, 
+//   MapInputDataError, 
+//   SubscribeToResponseError, 
+//   RegisterTimeoutError, 
+//   ExecActivityError, 
+//   DuplicateActivityError} from '../../../modules/errors';
 import {
   ActivityData,
   ActivityMetadata,

--- a/services/store/index.ts
+++ b/services/store/index.ts
@@ -32,7 +32,7 @@ abstract class StoreService {
   abstract setJob(jobId: any, data: Record<string, unknown>, metadata: Record<string, unknown>, config: AppVersion, multi? : any): Promise<any|string>;
   abstract setJobStats(jobKey: string, jobId: string, dateTime: string, stats: StatsType, appVersion: AppVersion, multi? : any): Promise<any|string>;
   abstract getJobStats(jobKeys: string[], config: AppVersion): Promise<JobStatsRange>;
-  abstract getJobIds(indexKeys: string[], config: AppVersion): Promise<IdsData>;
+  abstract getJobIds(indexKeys: string[], idRange: [number, number]): Promise<IdsData>;
   abstract updateJobStatus(jobId: string, collationKeyStatus: number, appVersion: AppVersion, multi? : any): Promise<any>
   abstract getJobMetadata(jobId: string, appVersion: AppVersion): Promise<object | undefined>;
   abstract getJobContext(jobId: string, appVersion: AppVersion): Promise<JobContext | undefined>;
@@ -48,6 +48,7 @@ abstract class StoreService {
   abstract getSchemas(config: AppVersion): Promise<any>;
   abstract setSchemas(schemas: Record<string, any>, config: AppVersion): Promise<any>;
   abstract setSubscriptions(subscriptions: Record<string, any>, config: AppVersion): Promise<any>;
+  abstract getSubscriptions(appVersion: AppVersion): Promise<Record<string, string>>;
   abstract getSubscription(topic: string, config: AppVersion): Promise<string | undefined>;
   abstract setTransitions(subscriptionsPatterns: Record<string, any>, config: AppVersion): Promise<any>;
   abstract getTransitions(config: AppVersion): Promise<any>;
@@ -59,8 +60,8 @@ abstract class StoreService {
   abstract publish(keyType: KeyType.CONDUCTOR, message: Record<string, any>, appVersion: AppVersion): Promise<void>;
   abstract addTaskQueues(keys: string[], appVersion: AppVersion): Promise<void>;
   abstract getActiveTaskQueue(appVersion: AppVersion): Promise<string | null>;
-  abstract processTaskQueue(id: string, newListKey: string): Promise<void>;
-  abstract deleteProcessedTaskQueue(key: string, processedKey: string, appVersion: AppVersion): Promise<void>;
+  abstract processTaskQueue(id: string, newListKey: string): Promise<any>;
+  abstract deleteProcessedTaskQueue(workItemKey: string, key: string, processedKey: string, appVersion: AppVersion): Promise<void>;
 }
 
 export { StoreService };

--- a/services/worker/index.ts
+++ b/services/worker/index.ts
@@ -1,32 +1,39 @@
 import { StoreService } from '../store';
 import { AppVersion } from '../../typedefs/app';
 import { ILogger } from '../logger';
+import { PubSubDBService } from '../pubsubdb';
 
 class WorkerService {
+  appVersion: AppVersion;
+  pubsSubDB: PubSubDBService;
   store: StoreService;
   logger: ILogger;
-  appVersion: AppVersion;
 
-  constructor(appVersion: AppVersion, store: StoreService, logger: ILogger) {
-    this.appVersion = appVersion;
-    this.logger = logger;
-    this.store = store;
+  constructor(appVersion: AppVersion,
+    pubSubDB: PubSubDBService,
+    store: StoreService,
+    logger: ILogger) {
+      this.appVersion = appVersion;
+      this.pubsSubDB = pubSubDB;
+      this.logger = logger;
+      this.store = store;
   }
 
   async processWorkItems(): Promise<void> {
     const workItemKey = await this.store.getActiveTaskQueue(this.appVersion);
-
     if (workItemKey) {
-      // Process the work item.
-      // ...
-
-      // Move the work item to the processed list.
-      const sourceKey = workItemKey;
-      const destinationKey = `${workItemKey}:processed`;
-      await this.store.processTaskQueue(sourceKey, destinationKey);
-
-      // Scrub the work item.
-      await this.store.deleteProcessedTaskQueue(sourceKey, destinationKey, this.appVersion);
+      const [topic, sourceKey, ...sdata] = workItemKey.split('::');
+      const data = JSON.parse(sdata.join('::'));
+      const destinationKey = `${sourceKey}:processed`;
+      const jobId = await this.store.processTaskQueue(sourceKey, destinationKey);
+      if (jobId) {
+        await this.pubsSubDB.hook(topic, {...data, id: jobId });
+        //todo: do final checksum count (values are tracked in the stats hash)
+      } else {
+        await this.store.deleteProcessedTaskQueue(workItemKey, sourceKey, destinationKey, this.appVersion);
+      }
+      //call in next tick
+      setImmediate(() => this.processWorkItems());
     }
   }
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -176,13 +176,34 @@ describe('pubsubdb', () => {
   });
 
   describe('hook()', () => {
-    it('should resolve the hook for', async () => {
+    it('should signal and awaken a sleeping job', async () => {
       const payload = {
-        id: 'ord_1055',
-        facility:'acme',
+        id: 'ord_1054',
+        facility:'spacely',
         actual_release_series: '202304110015',
       };
       const response = await pubSubDB.hook('order.routed', payload);
+      await new Promise(resolve => setTimeout(resolve, 1000));
+      expect(response).not.toBeNull();
+    });
+  });
+
+  describe('hookAll()', () => {
+    it('should signal and awaken all jobs of a certain type', async () => {
+      const payload = {
+        facility:'acme',
+        actual_release_series: '202304110015',
+      };
+      const query: JobStatsInput = {
+        data: {
+          color: 'red',
+          primacy: 'primary',
+          size: 'lg',
+        },
+        range: '1h',
+        end: 'NOW',
+      };
+      const response = await pubSubDB.hookAll('order.routed', payload, query, ['color:red']);
       await new Promise(resolve => setTimeout(resolve, 1000));
       expect(response).not.toBeNull();
     });

--- a/tests/services/reporter/index.test.ts
+++ b/tests/services/reporter/index.test.ts
@@ -57,7 +57,7 @@ describe('ReporterService', () => {
 
   beforeEach(() => {
     jest.resetAllMocks();
-    reporter = new ReporterService(appId, appVersion, redisStore, logger);
+    reporter = new ReporterService({ id: appId, version: appVersion }, redisStore, logger);
   });
 
   afterAll(async () => {
@@ -135,4 +135,28 @@ describe('ReporterService', () => {
       expect(result).toHaveProperty('segments');
     });
   });
+
+  describe('getWorkItems', () => {
+    it('should return Redis keys based on given options and facets', async () => {
+      const getStatsOptions = {
+        key: 'testKey',
+        granularity: '5m',
+        range: '1h',
+        end: 'NOW',
+      };
+      const facets = ['facet1', 'facet2'];
+      const mockedIdsData = {
+        'some:key:index:facet1': ['id1', 'id2'],
+        'some:key:index:facet2': ['id3', 'id4'],
+      };
+      const expectedWorkerLists = [
+        'some:key:index:facet1',
+        'some:key:index:facet2',
+      ];
+      (redisStore.getJobIds as jest.Mock).mockResolvedValue(mockedIdsData);
+      const result = await reporter.getWorkItems(getStatsOptions, facets);
+      expect(redisStore.getJobIds).toHaveBeenCalledWith(expect.any(Array), expect.any(Array));
+      expect(result).toEqual(expectedWorkerLists);
+    });
+  });  
 });

--- a/tests/services/store/stores/ioredis.test.ts
+++ b/tests/services/store/stores/ioredis.test.ts
@@ -342,11 +342,12 @@ describe('IORedisStoreService', () => {
 
     it('should remove the work item and processed item from Redis', async () => {
       const workItemKey = 'work-item-1';
+      const key = 'item-1';
       const processedKey = 'processed-item-1';
       const zsetKey = redisStoreService.mintKey(KeyType.WORK_ITEMS, { appId: appConfig.id });
       await redisStoreService.redisClient.zadd(zsetKey, 'NX', 1000, workItemKey);
       await redisStoreService.redisClient.set(processedKey, 'processed data');
-      await redisStoreService.deleteProcessedTaskQueue(workItemKey, processedKey, appConfig);
+      await redisStoreService.deleteProcessedTaskQueue(workItemKey, key, processedKey, appConfig);
       const workItemExists = await redisStoreService.redisClient.exists(workItemKey);
       const processedItemExists = await redisStoreService.redisClient.exists(processedKey);
       const workItemInZSet = await redisStoreService.redisClient.zrank(zsetKey, workItemKey);
@@ -357,8 +358,10 @@ describe('IORedisStoreService', () => {
 
     it('should remove the work item from the cache', async () => {
       const workItemKey = 'work-item-cached';
+      const key = 'item-cached';
+      const processedKey = 'processed-item-cached';
       redisStoreService.cache.setWorkItem(appConfig.id, workItemKey);
-      await redisStoreService.deleteProcessedTaskQueue(workItemKey, 'processed-item-cached', appConfig);
+      await redisStoreService.deleteProcessedTaskQueue(workItemKey, key, processedKey, appConfig);
       const cachedWorkItem = redisStoreService.cache.getActiveTaskQueue(appConfig.id);
       expect(cachedWorkItem).toBeUndefined();
     });
@@ -377,11 +380,20 @@ describe('IORedisStoreService', () => {
 
     it('should move an item from the source list to the destination list', async () => {
       await redisStoreService.redisClient.lpush(sourceKey, item1, item2);
-      await redisStoreService.processTaskQueue(sourceKey, destinationKey);
-      const sourceList = await redisStoreService.redisClient.lrange(sourceKey, 0, -1);
-      const destinationList = await redisStoreService.redisClient.lrange(destinationKey, 0, -1);
+      const val2 = await redisStoreService.processTaskQueue(sourceKey, destinationKey);
+      let sourceList = await redisStoreService.redisClient.lrange(sourceKey, 0, -1);
+      let destinationList = await redisStoreService.redisClient.lrange(destinationKey, 0, -1);
+      expect(val2).toEqual(item2);
       expect(sourceList).toEqual([item1]);
       expect(destinationList).toEqual([item2]);
+      const val1 = await redisStoreService.processTaskQueue(sourceKey, destinationKey);
+      expect(val1).toEqual(item1);
+      sourceList = await redisStoreService.redisClient.lrange(sourceKey, 0, -1);
+      destinationList = await redisStoreService.redisClient.lrange(destinationKey, 0, -1);
+      const val3 = await redisStoreService.processTaskQueue(sourceKey, destinationKey);
+      expect(val3).toEqual(null);
+      expect(sourceList).toEqual([]);
+      expect(destinationList).toEqual([item2, item1]);
     });
 
     it('should not move any item when the source list is empty', async () => {

--- a/typedefs/app.ts
+++ b/typedefs/app.ts
@@ -9,4 +9,13 @@ type AppVersion = {
   id: string;
 };
 
-export { App, AppVersion };
+type AppTransitions = {
+  [key: string]: Record<string, unknown>;
+};
+
+type AppSubscriptions = {
+  [key: string]: string;
+};
+
+
+export { App, AppVersion, AppTransitions, AppSubscriptions };

--- a/typedefs/conductor.ts
+++ b/typedefs/conductor.ts
@@ -4,10 +4,15 @@
  * These messages serve to coordinate the cache invalidation and switch-over
  * to the new version without any downtime and a coordinating parent server.
  */
-export type ConductorMessage = PingMessage | PongMessage | ActivateMessage;
+export type ConductorMessage = PingMessage | PongMessage | ActivateMessage | WorkMessage;
 
 export interface PingMessage {
   type: 'ping';
+  originator: string; //guid
+}
+
+export interface WorkMessage {
+  type: 'work';
   originator: string; //guid
 }
 


### PR DESCRIPTION
Added support for facet-based job processing. Assume a set of 100k jobs are published to topic 'a.b.c'. By calling the hookAll endpoint, the caller can specify those facets that an order must possess in order to be targeted by the worker swarm. The swarm will stop once all possible jobs have been updated and awakened from hibernation with the provided payload. For example

```javascript
  describe('hookAll()', () => {
    it('should signal and awaken all jobs of a certain type', async () => {
      const payload = {
        facility:'acme',
        actual_release_series: '202304110015',
      };
      const query: JobStatsInput = {
        data: {
          color: 'red',
          primacy: 'primary',
          size: 'lg',
        },
        range: '1h',
        end: 'NOW',
      };
      const response = await pubSubDB.hookAll('order.routed', payload, query, ['color:red']);
      await new Promise(resolve => setTimeout(resolve, 1000));
      expect(response).not.toBeNull();
    });
  });
```